### PR TITLE
Fix broken virtualenv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Demonstration app to show how Dedupe might be used as a geocoder
 
 **Install app requirements**
 
-We recommend using [virtualenv](http://virtualenv.readthedocs.org/en/latest/virtualenv.html) and [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/install.html) for working in a virtualized development environment. [Read how to set up virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
+We recommend using [virtualenv](https://virtualenv.pypa.io/en/latest/) and [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/install.html) for working in a virtualized development environment. [Read how to set up virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 
 Once you have virtualenvwrapper set up,
 


### PR DESCRIPTION
I noticed that the readthedocs link for virtualenv was broken, so I found the new URL and updated it.